### PR TITLE
Fix bug with Ransack::Visitor 'or'

### DIFF
--- a/lib/ransack/adapters/mongoid/ransack/visitor.rb
+++ b/lib/ransack/adapters/mongoid/ransack/visitor.rb
@@ -5,7 +5,7 @@ module Ransack
       nodes.inject(&:and)
     end
 
-    def visit_and(object)
+    def visit_or(object)
       nodes = object.values.map { |o| accept(o) }.compact
       nodes.inject(&:or)
     end


### PR DESCRIPTION
The second method in `Ransack::Visitor` needs to be named `visit_or`